### PR TITLE
Force and set LF line ending on subject repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ This is a bit Windows-centric for now.
     your Documents folder but this can be changed on every run, though not persistently.     
 5. Workflow Loop
     1. Run `Reset Current To Upstream`
+        * This will set the repository to `core.autocrlf=False` and re-checkout files to normalize the repository
+          to LF line endings. This only happens once if needed and is for users who use Git for Windows AND WSL.
     2. Run `Run Editor Server`
         * This will run forever until stopped
     3. Visit http://localhost:5000     

--- a/repo_operations.py
+++ b/repo_operations.py
@@ -10,6 +10,21 @@ from git import Repo
 def fetch_reset_new_branch_upstream(repo_path: Path):
     print("* Starting to fetch from Comma Repo")
     repo = Repo(repo_path)
+
+    # For people using Windows who use Git on Windows and WSL.
+    with open(str(repo_path / 'README.md'), 'rb') as readme_file:
+        if b'\r\n' in readme_file:
+            perform_normalize_to_lf = True
+        else:
+            perform_normalize_to_lf = False
+    if perform_normalize_to_lf:
+        print("CRLF line ending repository detected, normalizing to LF line ending.")
+        with repo.config_writer() as config_writer:
+            config_writer.set_value('core', 'autocrlf', 'false')
+        repo.git.rm('--cached', '-r', '.')
+        repo.git.reset('--hard')
+        print("Finished Normalizing to LF line ending.")
+
     # Force upstream to be comma10k repo
     if 'upstream' not in repo.remotes:
         repo.create_remote('upstream', 'https://github.com/commaai/comma10k')


### PR DESCRIPTION
Closes #5 

The files aren't modified. However, Git for Windows operates in CRLF line endings by default.

Force the repo to be LF endings on the fetch and reset command.